### PR TITLE
add odd-width integer encode/decode (uint24/40/48/56, int24/40/48/56)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,13 +29,21 @@ target_sources(
     src/int.c
     src/int8.c
     src/int16.c
+    src/int24.c
     src/int32.c
+    src/int40.c
+    src/int48.c
+    src/int56.c
     src/int64.c
     src/uint.c
     src/uint8.c
     src/uint8array.c
     src/uint16.c
+    src/uint24.c
     src/uint32.c
+    src/uint40.c
+    src/uint48.c
+    src/uint56.c
     src/uint64.c
     src/utf8.c
     src/zig-zag.h

--- a/include/compact.h
+++ b/include/compact.h
@@ -113,6 +113,42 @@ int
 compact_decode_uint64be (compact_state_t *state, uint64_t *result);
 
 int
+compact_preencode_uint24 (compact_state_t *state, uint32_t n);
+
+int
+compact_encode_uint24 (compact_state_t *state, uint32_t n);
+
+int
+compact_decode_uint24 (compact_state_t *state, uint32_t *result);
+
+int
+compact_preencode_uint40 (compact_state_t *state, uint64_t n);
+
+int
+compact_encode_uint40 (compact_state_t *state, uint64_t n);
+
+int
+compact_decode_uint40 (compact_state_t *state, uint64_t *result);
+
+int
+compact_preencode_uint48 (compact_state_t *state, uint64_t n);
+
+int
+compact_encode_uint48 (compact_state_t *state, uint64_t n);
+
+int
+compact_decode_uint48 (compact_state_t *state, uint64_t *result);
+
+int
+compact_preencode_uint56 (compact_state_t *state, uint64_t n);
+
+int
+compact_encode_uint56 (compact_state_t *state, uint64_t n);
+
+int
+compact_decode_uint56 (compact_state_t *state, uint64_t *result);
+
+int
 compact_preencode_int (compact_state_t *state, intmax_t n);
 
 int
@@ -192,6 +228,42 @@ compact_encode_int64be (compact_state_t *state, int64_t n);
 
 int
 compact_decode_int64be (compact_state_t *state, int64_t *result);
+
+int
+compact_preencode_int24 (compact_state_t *state, int32_t n);
+
+int
+compact_encode_int24 (compact_state_t *state, int32_t n);
+
+int
+compact_decode_int24 (compact_state_t *state, int32_t *result);
+
+int
+compact_preencode_int40 (compact_state_t *state, int64_t n);
+
+int
+compact_encode_int40 (compact_state_t *state, int64_t n);
+
+int
+compact_decode_int40 (compact_state_t *state, int64_t *result);
+
+int
+compact_preencode_int48 (compact_state_t *state, int64_t n);
+
+int
+compact_encode_int48 (compact_state_t *state, int64_t n);
+
+int
+compact_decode_int48 (compact_state_t *state, int64_t *result);
+
+int
+compact_preencode_int56 (compact_state_t *state, int64_t n);
+
+int
+compact_encode_int56 (compact_state_t *state, int64_t n);
+
+int
+compact_decode_int56 (compact_state_t *state, int64_t *result);
 
 int
 compact_preencode_float32 (compact_state_t *state, float n);

--- a/src/int24.c
+++ b/src/int24.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_int24 (compact_state_t *state, int32_t n) {
+  state->end += 3;
+
+  return 0;
+}
+
+int
+compact_encode_int24 (compact_state_t *state, int32_t n) {
+  uint32_t z = n < 0 ? ((uint32_t) (-n - 1) << 1) | 1 : (uint32_t) n << 1;
+  return compact_encode_uint24(state, z);
+}
+
+int
+compact_decode_int24 (compact_state_t *state, int32_t *result) {
+  uint32_t n;
+  int err = compact_decode_uint24(state, result ? &n : NULL);
+  if (err < 0) return err;
+
+  if (result) *result = (n & 1) ? -(int32_t) (n >> 1) - 1 : (int32_t) (n >> 1);
+
+  return 0;
+}

--- a/src/int24.c
+++ b/src/int24.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 
 #include "../include/compact.h"
+#include "zig-zag.h"
 
 int
 compact_preencode_int24 (compact_state_t *state, int32_t n) {
@@ -11,8 +12,7 @@ compact_preencode_int24 (compact_state_t *state, int32_t n) {
 
 int
 compact_encode_int24 (compact_state_t *state, int32_t n) {
-  uint32_t z = n < 0 ? ((uint32_t) (-n - 1) << 1) | 1 : (uint32_t) n << 1;
-  return compact_encode_uint24(state, z);
+  return compact_encode_uint24(state, compact_encode_zig_zag(32, n));
 }
 
 int
@@ -21,7 +21,7 @@ compact_decode_int24 (compact_state_t *state, int32_t *result) {
   int err = compact_decode_uint24(state, result ? &n : NULL);
   if (err < 0) return err;
 
-  if (result) *result = (n & 1) ? -(int32_t) (n >> 1) - 1 : (int32_t) (n >> 1);
+  if (result) *result = compact_decode_zig_zag(32, n);
 
   return 0;
 }

--- a/src/int40.c
+++ b/src/int40.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 
 #include "../include/compact.h"
+#include "zig-zag.h"
 
 int
 compact_preencode_int40 (compact_state_t *state, int64_t n) {
@@ -11,8 +12,7 @@ compact_preencode_int40 (compact_state_t *state, int64_t n) {
 
 int
 compact_encode_int40 (compact_state_t *state, int64_t n) {
-  uint64_t z = n < 0 ? ((uint64_t) (-n - 1) << 1) | 1 : (uint64_t) n << 1;
-  return compact_encode_uint40(state, z);
+  return compact_encode_uint40(state, compact_encode_zig_zag(64, n));
 }
 
 int
@@ -21,7 +21,7 @@ compact_decode_int40 (compact_state_t *state, int64_t *result) {
   int err = compact_decode_uint40(state, result ? &n : NULL);
   if (err < 0) return err;
 
-  if (result) *result = (n & 1) ? -(int64_t) (n >> 1) - 1 : (int64_t) (n >> 1);
+  if (result) *result = compact_decode_zig_zag(64, n);
 
   return 0;
 }

--- a/src/int40.c
+++ b/src/int40.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_int40 (compact_state_t *state, int64_t n) {
+  state->end += 5;
+
+  return 0;
+}
+
+int
+compact_encode_int40 (compact_state_t *state, int64_t n) {
+  uint64_t z = n < 0 ? ((uint64_t) (-n - 1) << 1) | 1 : (uint64_t) n << 1;
+  return compact_encode_uint40(state, z);
+}
+
+int
+compact_decode_int40 (compact_state_t *state, int64_t *result) {
+  uint64_t n;
+  int err = compact_decode_uint40(state, result ? &n : NULL);
+  if (err < 0) return err;
+
+  if (result) *result = (n & 1) ? -(int64_t) (n >> 1) - 1 : (int64_t) (n >> 1);
+
+  return 0;
+}

--- a/src/int48.c
+++ b/src/int48.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_int48 (compact_state_t *state, int64_t n) {
+  state->end += 6;
+
+  return 0;
+}
+
+int
+compact_encode_int48 (compact_state_t *state, int64_t n) {
+  uint64_t z = n < 0 ? ((uint64_t) (-n - 1) << 1) | 1 : (uint64_t) n << 1;
+  return compact_encode_uint48(state, z);
+}
+
+int
+compact_decode_int48 (compact_state_t *state, int64_t *result) {
+  uint64_t n;
+  int err = compact_decode_uint48(state, result ? &n : NULL);
+  if (err < 0) return err;
+
+  if (result) *result = (n & 1) ? -(int64_t) (n >> 1) - 1 : (int64_t) (n >> 1);
+
+  return 0;
+}

--- a/src/int48.c
+++ b/src/int48.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 
 #include "../include/compact.h"
+#include "zig-zag.h"
 
 int
 compact_preencode_int48 (compact_state_t *state, int64_t n) {
@@ -11,8 +12,7 @@ compact_preencode_int48 (compact_state_t *state, int64_t n) {
 
 int
 compact_encode_int48 (compact_state_t *state, int64_t n) {
-  uint64_t z = n < 0 ? ((uint64_t) (-n - 1) << 1) | 1 : (uint64_t) n << 1;
-  return compact_encode_uint48(state, z);
+  return compact_encode_uint48(state, compact_encode_zig_zag(64, n));
 }
 
 int
@@ -21,7 +21,7 @@ compact_decode_int48 (compact_state_t *state, int64_t *result) {
   int err = compact_decode_uint48(state, result ? &n : NULL);
   if (err < 0) return err;
 
-  if (result) *result = (n & 1) ? -(int64_t) (n >> 1) - 1 : (int64_t) (n >> 1);
+  if (result) *result = compact_decode_zig_zag(64, n);
 
   return 0;
 }

--- a/src/int56.c
+++ b/src/int56.c
@@ -1,0 +1,27 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_int56 (compact_state_t *state, int64_t n) {
+  state->end += 7;
+
+  return 0;
+}
+
+int
+compact_encode_int56 (compact_state_t *state, int64_t n) {
+  uint64_t z = n < 0 ? ((uint64_t) (-n - 1) << 1) | 1 : (uint64_t) n << 1;
+  return compact_encode_uint56(state, z);
+}
+
+int
+compact_decode_int56 (compact_state_t *state, int64_t *result) {
+  uint64_t n;
+  int err = compact_decode_uint56(state, result ? &n : NULL);
+  if (err < 0) return err;
+
+  if (result) *result = (n & 1) ? -(int64_t) (n >> 1) - 1 : (int64_t) (n >> 1);
+
+  return 0;
+}

--- a/src/int56.c
+++ b/src/int56.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 
 #include "../include/compact.h"
+#include "zig-zag.h"
 
 int
 compact_preencode_int56 (compact_state_t *state, int64_t n) {
@@ -11,8 +12,7 @@ compact_preencode_int56 (compact_state_t *state, int64_t n) {
 
 int
 compact_encode_int56 (compact_state_t *state, int64_t n) {
-  uint64_t z = n < 0 ? ((uint64_t) (-n - 1) << 1) | 1 : (uint64_t) n << 1;
-  return compact_encode_uint56(state, z);
+  return compact_encode_uint56(state, compact_encode_zig_zag(64, n));
 }
 
 int
@@ -21,7 +21,7 @@ compact_decode_int56 (compact_state_t *state, int64_t *result) {
   int err = compact_decode_uint56(state, result ? &n : NULL);
   if (err < 0) return err;
 
-  if (result) *result = (n & 1) ? -(int64_t) (n >> 1) - 1 : (int64_t) (n >> 1);
+  if (result) *result = compact_decode_zig_zag(64, n);
 
   return 0;
 }

--- a/src/uint24.c
+++ b/src/uint24.c
@@ -1,0 +1,32 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_uint24 (compact_state_t *state, uint32_t n) {
+  state->end += 3;
+
+  return 0;
+}
+
+int
+compact_encode_uint24 (compact_state_t *state, uint32_t n) {
+  state->buffer[state->start] = n;
+  state->buffer[state->start + 1] = n >> 8;
+  state->buffer[state->start + 2] = n >> 16;
+
+  state->start += 3;
+
+  return 0;
+}
+
+int
+compact_decode_uint24 (compact_state_t *state, uint32_t *result) {
+  if (state->end - state->start < 3) return -1;
+
+  if (result) *result = (uint32_t) state->buffer[state->start] | ((uint32_t) state->buffer[state->start + 1] << 8) | ((uint32_t) state->buffer[state->start + 2] << 16);
+
+  state->start += 3;
+
+  return 0;
+}

--- a/src/uint40.c
+++ b/src/uint40.c
@@ -1,0 +1,34 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_uint40 (compact_state_t *state, uint64_t n) {
+  state->end += 5;
+
+  return 0;
+}
+
+int
+compact_encode_uint40 (compact_state_t *state, uint64_t n) {
+  state->buffer[state->start] = n;
+  state->buffer[state->start + 1] = n >> 8;
+  state->buffer[state->start + 2] = n >> 16;
+  state->buffer[state->start + 3] = n >> 24;
+  state->buffer[state->start + 4] = n >> 32;
+
+  state->start += 5;
+
+  return 0;
+}
+
+int
+compact_decode_uint40 (compact_state_t *state, uint64_t *result) {
+  if (state->end - state->start < 5) return -1;
+
+  if (result) *result = (uint64_t) state->buffer[state->start] | ((uint64_t) state->buffer[state->start + 1] << 8) | ((uint64_t) state->buffer[state->start + 2] << 16) | ((uint64_t) state->buffer[state->start + 3] << 24) | ((uint64_t) state->buffer[state->start + 4] << 32);
+
+  state->start += 5;
+
+  return 0;
+}

--- a/src/uint48.c
+++ b/src/uint48.c
@@ -1,0 +1,35 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_uint48 (compact_state_t *state, uint64_t n) {
+  state->end += 6;
+
+  return 0;
+}
+
+int
+compact_encode_uint48 (compact_state_t *state, uint64_t n) {
+  state->buffer[state->start] = n;
+  state->buffer[state->start + 1] = n >> 8;
+  state->buffer[state->start + 2] = n >> 16;
+  state->buffer[state->start + 3] = n >> 24;
+  state->buffer[state->start + 4] = n >> 32;
+  state->buffer[state->start + 5] = n >> 40;
+
+  state->start += 6;
+
+  return 0;
+}
+
+int
+compact_decode_uint48 (compact_state_t *state, uint64_t *result) {
+  if (state->end - state->start < 6) return -1;
+
+  if (result) *result = (uint64_t) state->buffer[state->start] | ((uint64_t) state->buffer[state->start + 1] << 8) | ((uint64_t) state->buffer[state->start + 2] << 16) | ((uint64_t) state->buffer[state->start + 3] << 24) | ((uint64_t) state->buffer[state->start + 4] << 32) | ((uint64_t) state->buffer[state->start + 5] << 40);
+
+  state->start += 6;
+
+  return 0;
+}

--- a/src/uint56.c
+++ b/src/uint56.c
@@ -1,0 +1,36 @@
+#include <stdint.h>
+
+#include "../include/compact.h"
+
+int
+compact_preencode_uint56 (compact_state_t *state, uint64_t n) {
+  state->end += 7;
+
+  return 0;
+}
+
+int
+compact_encode_uint56 (compact_state_t *state, uint64_t n) {
+  state->buffer[state->start] = n;
+  state->buffer[state->start + 1] = n >> 8;
+  state->buffer[state->start + 2] = n >> 16;
+  state->buffer[state->start + 3] = n >> 24;
+  state->buffer[state->start + 4] = n >> 32;
+  state->buffer[state->start + 5] = n >> 40;
+  state->buffer[state->start + 6] = n >> 48;
+
+  state->start += 7;
+
+  return 0;
+}
+
+int
+compact_decode_uint56 (compact_state_t *state, uint64_t *result) {
+  if (state->end - state->start < 7) return -1;
+
+  if (result) *result = (uint64_t) state->buffer[state->start] | ((uint64_t) state->buffer[state->start + 1] << 8) | ((uint64_t) state->buffer[state->start + 2] << 16) | ((uint64_t) state->buffer[state->start + 3] << 24) | ((uint64_t) state->buffer[state->start + 4] << 32) | ((uint64_t) state->buffer[state->start + 5] << 40) | ((uint64_t) state->buffer[state->start + 6] << 48);
+
+  state->start += 7;
+
+  return 0;
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,12 +5,20 @@ list(APPEND tests
   int
   int8
   int16
+  int24
   int32
+  int40
+  int48
+  int56
   int64
   uint
   uint8
   uint16
+  uint24
   uint32
+  uint40
+  uint48
+  uint56
   uint64
 )
 

--- a/test/int24.c
+++ b/test/int24.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_int24(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_int24(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 3); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_int24(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    int32_t decoded; \
+    err = compact_decode_int24(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_int24(0);
+  test_int24(1);
+  test_int24(-1);
+  test_int24(127);
+  test_int24(-128);
+  test_int24(8388607);
+  test_int24(-8388608);
+}

--- a/test/int40.c
+++ b/test/int40.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_int40(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_int40(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 5); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_int40(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    int64_t decoded; \
+    err = compact_decode_int40(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_int40(0);
+  test_int40(1);
+  test_int40(-1);
+  test_int40(549755813887LL);
+  test_int40(-549755813888LL);
+}

--- a/test/int48.c
+++ b/test/int48.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_int48(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_int48(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 6); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_int48(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    int64_t decoded; \
+    err = compact_decode_int48(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_int48(0);
+  test_int48(1);
+  test_int48(-1);
+  test_int48(140737488355327LL);
+  test_int48(-140737488355328LL);
+}

--- a/test/int56.c
+++ b/test/int56.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_int56(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_int56(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 7); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_int56(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    int64_t decoded; \
+    err = compact_decode_int56(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_int56(0);
+  test_int56(1);
+  test_int56(-1);
+  test_int56(36028797018963967LL);
+  test_int56(-36028797018963968LL);
+}

--- a/test/uint24.c
+++ b/test/uint24.c
@@ -1,0 +1,40 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_uint24(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_uint24(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 3); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_uint24(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    uint32_t decoded; \
+    err = compact_decode_uint24(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_uint24(0);
+  test_uint24(1);
+  test_uint24(255);
+  test_uint24(256);
+  test_uint24(65535);
+  test_uint24(65536);
+  test_uint24(0xFFFFFF);
+}

--- a/test/uint40.c
+++ b/test/uint40.c
@@ -1,0 +1,38 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_uint40(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_uint40(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 5); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_uint40(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    uint64_t decoded; \
+    err = compact_decode_uint40(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_uint40(0);
+  test_uint40(1);
+  test_uint40(0xFFFFFF);
+  test_uint40(0xFFFFFFFF);
+  test_uint40(0xFFFFFFFFFFULL);
+}

--- a/test/uint48.c
+++ b/test/uint48.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_uint48(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_uint48(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 6); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_uint48(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    uint64_t decoded; \
+    err = compact_decode_uint48(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_uint48(0);
+  test_uint48(1);
+  test_uint48(0xFFFFFFFFFFULL);
+  test_uint48(0xFFFFFFFFFFFFULL);
+}

--- a/test/uint56.c
+++ b/test/uint56.c
@@ -1,0 +1,37 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "../include/compact.h"
+
+#define test_uint56(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_uint56(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 7); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_uint56(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    uint64_t decoded; \
+    err = compact_decode_uint56(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+  }
+
+int
+main () {
+  test_uint56(0);
+  test_uint56(1);
+  test_uint56(0xFFFFFFFFFFFFULL);
+  test_uint56(0xFFFFFFFFFFFFFFULL);
+}


### PR DESCRIPTION
Adds preencode/encode/decode for eight odd-width integer types. Unsigned types use little-endian fixed-byte encoding; signed types use zig-zag over the same byte width.