### PR TITLE
use uint64_t/int64_t in varint public api

### DIFF
--- a/include/compact.h
+++ b/include/compact.h
@@ -32,22 +32,22 @@ int
 compact_decode_bool (compact_state_t *state, bool *result);
 
 int
-compact_preencode_uint (compact_state_t *state, uintmax_t n);
+compact_preencode_uint (compact_state_t *state, uint64_t n);
 
 int
-compact_encode_uint (compact_state_t *state, uintmax_t n);
+compact_encode_uint (compact_state_t *state, uint64_t n);
 
 int
-compact_decode_uint (compact_state_t *state, uintmax_t *result);
+compact_decode_uint (compact_state_t *state, uint64_t *result);
 
 int
-compact_preencode_uintbe (compact_state_t *state, uintmax_t n);
+compact_preencode_uintbe (compact_state_t *state, uint64_t n);
 
 int
-compact_encode_uintbe (compact_state_t *state, uintmax_t n);
+compact_encode_uintbe (compact_state_t *state, uint64_t n);
 
 int
-compact_decode_uintbe (compact_state_t *state, uintmax_t *result);
+compact_decode_uintbe (compact_state_t *state, uint64_t *result);
 
 int
 compact_preencode_uint8 (compact_state_t *state, uint8_t n);
@@ -149,22 +149,22 @@ int
 compact_decode_uint56 (compact_state_t *state, uint64_t *result);
 
 int
-compact_preencode_int (compact_state_t *state, intmax_t n);
+compact_preencode_int (compact_state_t *state, int64_t n);
 
 int
-compact_encode_int (compact_state_t *state, intmax_t n);
+compact_encode_int (compact_state_t *state, int64_t n);
 
 int
-compact_decode_int (compact_state_t *state, intmax_t *result);
+compact_decode_int (compact_state_t *state, int64_t *result);
 
 int
-compact_preencode_intbe (compact_state_t *state, intmax_t n);
+compact_preencode_intbe (compact_state_t *state, int64_t n);
 
 int
-compact_encode_intbe (compact_state_t *state, intmax_t n);
+compact_encode_intbe (compact_state_t *state, int64_t n);
 
 int
-compact_decode_intbe (compact_state_t *state, intmax_t *result);
+compact_decode_intbe (compact_state_t *state, int64_t *result);
 
 int
 compact_preencode_int8 (compact_state_t *state, int8_t n);

--- a/src/int.c
+++ b/src/int.c
@@ -1,28 +1,21 @@
-#include <assert.h>
 #include <stdint.h>
 
 #include "../include/compact.h"
 #include "zig-zag.h"
 
 int
-compact_preencode_int (compact_state_t *state, intmax_t n) {
-  assert(sizeof(intmax_t) == 8);
-
+compact_preencode_int (compact_state_t *state, int64_t n) {
   return compact_preencode_uint(state, compact_encode_zig_zag(64, n));
 }
 
 int
-compact_encode_int (compact_state_t *state, intmax_t n) {
-  assert(sizeof(intmax_t) == 8);
-
+compact_encode_int (compact_state_t *state, int64_t n) {
   return compact_encode_uint(state, compact_encode_zig_zag(64, n));
 }
 
 int
-compact_decode_int (compact_state_t *state, intmax_t *result) {
-  assert(sizeof(intmax_t) == 8);
-
-  uintmax_t n;
+compact_decode_int (compact_state_t *state, int64_t *result) {
+  uint64_t n;
   int err = compact_decode_uint(state, result ? &n : NULL);
   if (err < 0) return err;
 
@@ -32,24 +25,18 @@ compact_decode_int (compact_state_t *state, intmax_t *result) {
 }
 
 int
-compact_preencode_intbe (compact_state_t *state, intmax_t n) {
-  assert(sizeof(intmax_t) == 8);
-
+compact_preencode_intbe (compact_state_t *state, int64_t n) {
   return compact_preencode_uintbe(state, compact_encode_zig_zag(64, n));
 }
 
 int
-compact_encode_intbe (compact_state_t *state, intmax_t n) {
-  assert(sizeof(intmax_t) == 8);
-
+compact_encode_intbe (compact_state_t *state, int64_t n) {
   return compact_encode_uintbe(state, compact_encode_zig_zag(64, n));
 }
 
 int
-compact_decode_intbe (compact_state_t *state, intmax_t *result) {
-  assert(sizeof(intmax_t) == 8);
-
-  uintmax_t n;
+compact_decode_intbe (compact_state_t *state, int64_t *result) {
+  uint64_t n;
   int err = compact_decode_uintbe(state, result ? &n : NULL);
   if (err < 0) return err;
 

--- a/src/uint.c
+++ b/src/uint.c
@@ -1,12 +1,9 @@
-#include <assert.h>
 #include <stdint.h>
 
 #include "../include/compact.h"
 
 int
-compact_preencode_uint (compact_state_t *state, uintmax_t n) {
-  assert(sizeof(uintmax_t) == 8);
-
+compact_preencode_uint (compact_state_t *state, uint64_t n) {
   state->end += n <= 0xfc         ? 1
                 : n <= 0xffff     ? 3
                 : n <= 0xffffffff ? 5
@@ -15,9 +12,7 @@ compact_preencode_uint (compact_state_t *state, uintmax_t n) {
 }
 
 int
-compact_encode_uint (compact_state_t *state, uintmax_t n) {
-  assert(sizeof(uintmax_t) == 8);
-
+compact_encode_uint (compact_state_t *state, uint64_t n) {
   if (n <= 0xfc) {
     return compact_encode_uint8(state, n & 0xff);
   }
@@ -40,9 +35,7 @@ compact_encode_uint (compact_state_t *state, uintmax_t n) {
 }
 
 int
-compact_decode_uint (compact_state_t *state, uintmax_t *result) {
-  assert(sizeof(uintmax_t) == 8);
-
+compact_decode_uint (compact_state_t *state, uint64_t *result) {
   int err;
 
   uint8_t uint8;
@@ -75,24 +68,19 @@ compact_decode_uint (compact_state_t *state, uintmax_t *result) {
     return 0;
   }
 
-  uint64_t uint64;
-  err = compact_decode_uint64(state, result ? &uint64 : NULL);
+  err = compact_decode_uint64(state, result);
   if (err < 0) return err;
-
-  if (result) *result = uint64;
 
   return 0;
 }
 
 int
-compact_preencode_uintbe (compact_state_t *state, uintmax_t n) {
+compact_preencode_uintbe (compact_state_t *state, uint64_t n) {
   return compact_preencode_uint(state, n);
 }
 
 int
-compact_encode_uintbe (compact_state_t *state, uintmax_t n) {
-  assert(sizeof(uintmax_t) == 8);
-
+compact_encode_uintbe (compact_state_t *state, uint64_t n) {
   if (n <= 0xfc) {
     return compact_encode_uint8(state, n & 0xff);
   }
@@ -115,9 +103,7 @@ compact_encode_uintbe (compact_state_t *state, uintmax_t n) {
 }
 
 int
-compact_decode_uintbe (compact_state_t *state, uintmax_t *result) {
-  assert(sizeof(uintmax_t) == 8);
-
+compact_decode_uintbe (compact_state_t *state, uint64_t *result) {
   int err;
 
   uint8_t uint8;
@@ -150,11 +136,8 @@ compact_decode_uintbe (compact_state_t *state, uintmax_t *result) {
     return 0;
   }
 
-  uint64_t uint64;
-  err = compact_decode_uint64be(state, result ? &uint64 : NULL);
+  err = compact_decode_uint64be(state, result);
   if (err < 0) return err;
-
-  if (result) *result = uint64;
 
   return 0;
 }

--- a/src/uint8array.c
+++ b/src/uint8array.c
@@ -28,7 +28,7 @@ compact_encode_uint8array (compact_state_t *state, const uint8_t *array, size_t 
 
 int
 compact_decode_uint8array (compact_state_t *state, uint8_t **result, size_t *len) {
-  uintmax_t size;
+  uint64_t size;
   int err = compact_decode_uint(state, &size);
   if (err < 0) return err;
 

--- a/src/utf8.c
+++ b/src/utf8.c
@@ -28,7 +28,7 @@ compact_encode_utf8 (compact_state_t *state, const utf8_string_view_t string) {
 
 int
 compact_decode_utf8 (compact_state_t *state, utf8_string_view_t *result) {
-  uintmax_t len;
+  uint64_t len;
   int err = compact_decode_uint(state, &len);
   if (err < 0) return err;
 

--- a/test/int.c
+++ b/test/int.c
@@ -20,7 +20,7 @@
 \
     state.start = 0; \
 \
-    intmax_t decoded; \
+    int64_t decoded; \
     err = compact_decode_int(&state, &decoded); \
     assert(err == 0); \
 \
@@ -44,7 +44,7 @@
 \
     state.start = 0; \
 \
-    intmax_t decoded; \
+    int64_t decoded; \
     err = compact_decode_intbe(&state, &decoded); \
     assert(err == 0); \
 \

--- a/test/uint.c
+++ b/test/uint.c
@@ -20,7 +20,7 @@
 \
     state.start = 0; \
 \
-    uintmax_t decoded; \
+    uint64_t decoded; \
     err = compact_decode_uint(&state, &decoded); \
     assert(err == 0); \
 \
@@ -44,7 +44,7 @@
 \
     state.start = 0; \
 \
-    uintmax_t decoded; \
+    uint64_t decoded; \
     err = compact_decode_uintbe(&state, &decoded); \
     assert(err == 0); \
 \


### PR DESCRIPTION
The varint encode/decode entry points (`compact_(pre)?encode_uint(_be)?`, `compact_decode_uint(_be)?`, plus the signed variants) used `uintmax_t`/`intmax_t` in their public signatures, but the implementations have always asserted `sizeof(uintmax_t) == 8` and worked through `uint64_t` internals. The wire format physically tops out at 64 bits, so the wider type was never load-bearing.

Switches the public API to `uint64_t`/`int64_t`, drops the now-redundant size asserts, and updates internal varint locals to match.