### PR TITLE
encode float32/float64 as IEEE bits instead of truncating to int

### DIFF
--- a/src/float32.c
+++ b/src/float32.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <string.h>
 
 #include "../include/compact.h"
 
@@ -11,16 +12,19 @@ compact_preencode_float32 (compact_state_t *state, float n) {
 
 int
 compact_encode_float32 (compact_state_t *state, float n) {
-  return compact_encode_uint32(state, (uint32_t) n);
+  uint32_t bits;
+  memcpy(&bits, &n, sizeof(bits));
+
+  return compact_encode_uint32(state, bits);
 }
 
 int
 compact_decode_float32 (compact_state_t *state, float *result) {
-  uint32_t n;
-  int err = compact_decode_uint32(state, result ? &n : NULL);
+  uint32_t bits;
+  int err = compact_decode_uint32(state, result ? &bits : NULL);
   if (err < 0) return err;
 
-  if (result) *result = (float) n;
+  if (result) memcpy(result, &bits, sizeof(*result));
 
   return 0;
 }

--- a/src/float64.c
+++ b/src/float64.c
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <string.h>
 
 #include "../include/compact.h"
 
@@ -11,16 +12,19 @@ compact_preencode_float64 (compact_state_t *state, double n) {
 
 int
 compact_encode_float64 (compact_state_t *state, double n) {
-  return compact_encode_uint64(state, (uint64_t) n);
+  uint64_t bits;
+  memcpy(&bits, &n, sizeof(bits));
+
+  return compact_encode_uint64(state, bits);
 }
 
 int
 compact_decode_float64 (compact_state_t *state, double *result) {
-  uint64_t n;
-  int err = compact_decode_uint64(state, result ? &n : NULL);
+  uint64_t bits;
+  int err = compact_decode_uint64(state, result ? &bits : NULL);
   if (err < 0) return err;
 
-  if (result) *result = (double) n;
+  if (result) memcpy(result, &bits, sizeof(*result));
 
   return 0;
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,8 @@ list(APPEND tests
   array-utf8
   fixed32
   fixed64
+  float32
+  float64
   int
   int8
   int16

--- a/test/float32.c
+++ b/test/float32.c
@@ -1,0 +1,44 @@
+#undef NDEBUG
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/compact.h"
+
+#define test_float32(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_float32(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 4); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_float32(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    float decoded; \
+    err = compact_decode_float32(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+\
+    free(state.buffer); \
+  }
+
+int
+main () {
+  test_float32(0.0f);
+  test_float32(1.0f);
+  test_float32(-1.0f);
+  test_float32(0.5f);
+  test_float32(-0.5f);
+  test_float32(3.5f);
+  test_float32(1e30f);
+}

--- a/test/float64.c
+++ b/test/float64.c
@@ -1,0 +1,44 @@
+#undef NDEBUG
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../include/compact.h"
+
+#define test_float64(n) \
+  { \
+    int err; \
+\
+    compact_state_t state = {0, 0}; \
+\
+    err = compact_preencode_float64(&state, n); \
+    assert(err == 0); \
+    assert(state.end == 8); \
+\
+    state.buffer = malloc(state.end); \
+\
+    err = compact_encode_float64(&state, n); \
+    assert(err == 0); \
+\
+    state.start = 0; \
+\
+    double decoded; \
+    err = compact_decode_float64(&state, &decoded); \
+    assert(err == 0); \
+\
+    assert(n == decoded); \
+\
+    free(state.buffer); \
+  }
+
+int
+main () {
+  test_float64(0.0);
+  test_float64(1.0);
+  test_float64(-1.0);
+  test_float64(0.5);
+  test_float64(-0.5);
+  test_float64(3.141592653589793);
+  test_float64(1e300);
+}


### PR DESCRIPTION
compact_encode_float32/64 cast the value to an integer, dropping the fraction (1.5 became 1), and decode did the reverse. Copy the IEEE bits via memcpy instead. Adds float32 and float64 round-trip tests, which the previous code failed.

Unblocks the float fixtures in hyperschema-c.